### PR TITLE
Automate a smoke test and deploy-on-tag using Travis CI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,37 @@
 dist: xenial
 language: go
 go:
-  - "1.11.x"
+- 1.11.x
 
 addons:
   apt:
     sources:
-      - sourceline: 'ppa:masterminds/glide'
+    - sourceline: ppa:masterminds/glide
     packages:
-      - glide
+    - glide
 
 install:
-  - glide install
+- glide install
 
 script:
-  - ./smoketest.sh
+- "./smoketest.sh"
+- make ambex
+- echo ${TRAVIS_TAG}
+
+before-deploy:
+- mkdir -p ambex-s3/ambex/${TRAVIS_TAG}/
+- cp ambex-for-image ambex-s3/ambex/${TRAVIS_TAG}/ambex
+
+deploy:
+  provider: s3
+  bucket: datawire-static-files
+  local_dir: ambex-s3
+  skip_cleanup: true
+  access_key_id: AKIAIH5JLBXLCNDGOLRA
+  secret_access_key:
+    secure: X/DYfqfz9Pbuw4QVt8e6DXKvYGObQcoE5l+B+tAZVmSSQ99WdEdB15eVEdGk5soPCjI3y9sYzzRtSKkJafW8txx/dSDgK2GH8uMHnqeH+aWUFreeMJcjSlg6KV5pgD+LJkztKFCrDyi9/LcBlhKQGBh+t0yt0SIOzTlECf9QLIw62MKOBULr7Iv2f7fle6DkBSpI64UaORKcX46bjxBhOg9pvkUC/1kMEhdYBDI1V2kTMnt9qvooyIkHWx5KFVXtT+yeJ2Km7Iciy8cQneIG4FVbJUyB8TLdDF4G1KFJkSGKMp8UG/dldikMbjuujtmgW6sSHkuqwnfThw9z0ScPLxbXzergQaen1ANZGkTAh4pQ3r8oi5/y6KalmkzdcHLiQ5OXhaPUlKU4XSymTP+yXL5bcriRMVg+JQo8WUjePx7zYhbvFHzLpjYMIgaEM6ybQUIx750EY5VGpD4BEOPrICJkU0UQ82+XKRl8+RQ+3c1Q+BC4d9g1xcAbCjCXV80XAco8fGKqvN+pu65h8beVNaFq2v9jm0ghCgCw5Avv5Z4U+dXBreNoZ49m8c94LfNMYpGjiqF666lWePRF3mtEejamVfi5yQ3Ez0KWhuuH3W6hRHqmeZ17e4y9stWIbR/IdJ7j2D5PNcPF7QGSrL/C+txVTH8rP820/heyVzBiEKI=
+  on:
+  - tags: true
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,8 @@ install:
 - glide install
 
 script:
+- make image
 - "./smoketest.sh"
-- make ambex
-- echo ${TRAVIS_TAG}
 
 before_deploy:
 - mkdir -p ambex-s3/ambex/${TRAVIS_TAG}/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ go:
   - "1.11.x"
 
 before_install:
-  - curl https://glide.sh/get | sh
-  - glide --version
-  - make --version
+  - sudo add-apt-repository ppa:masterminds/glide -y
+  - sudo apt-get update -q
+  - sudo apt-get install glide -y
   - glide install
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ go:
 before_install:
   - curl https://glide.sh/get | sh
   - glide --version
+  - make --version
+  - glide install
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,8 @@ go:
   - "1.11.x"
 
 before_install:
-  - sudo add-apt-repository ppa:masterminds/glide -y
-  - sudo apt-get update -q
-  - sudo apt-get install glide -y
+  - curl https://glide.sh/get | sh
   - glide --version
 
 notifications:
   email: false
-
-addons:
-  artifacts:
-    paths:
-      - ambex
-    target_paths:
-      - ambex/$TRAVIS_TAG/$(go env GOOS)/$(go env GOARCH)
-    debug: true
-    s3_region: "us-east-1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
 
 before_deploy:
 - mkdir -p ambex-s3/ambex/${TRAVIS_TAG}/
-- cp ambex-for-image ambex-s3/ambex/${TRAVIS_TAG}/ambex
+- cp ambex_for_image ambex-s3/ambex/${TRAVIS_TAG}/ambex
 
 deploy:
   provider: s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ before_install:
   - sudo add-apt-repository ppa:masterminds/glide -y
   - sudo apt-get update -q
   - sudo apt-get install glide -y
+  - glide --version
+
+notifications:
+  email: false
 
 addons:
   artifacts:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
 - make ambex
 - echo ${TRAVIS_TAG}
 
-before-deploy:
+before_deploy:
 - mkdir -p ambex-s3/ambex/${TRAVIS_TAG}/
 - cp ambex-for-image ambex-s3/ambex/${TRAVIS_TAG}/ambex
 
@@ -31,7 +31,7 @@ deploy:
   secret_access_key:
     secure: X/DYfqfz9Pbuw4QVt8e6DXKvYGObQcoE5l+B+tAZVmSSQ99WdEdB15eVEdGk5soPCjI3y9sYzzRtSKkJafW8txx/dSDgK2GH8uMHnqeH+aWUFreeMJcjSlg6KV5pgD+LJkztKFCrDyi9/LcBlhKQGBh+t0yt0SIOzTlECf9QLIw62MKOBULr7Iv2f7fle6DkBSpI64UaORKcX46bjxBhOg9pvkUC/1kMEhdYBDI1V2kTMnt9qvooyIkHWx5KFVXtT+yeJ2Km7Iciy8cQneIG4FVbJUyB8TLdDF4G1KFJkSGKMp8UG/dldikMbjuujtmgW6sSHkuqwnfThw9z0ScPLxbXzergQaen1ANZGkTAh4pQ3r8oi5/y6KalmkzdcHLiQ5OXhaPUlKU4XSymTP+yXL5bcriRMVg+JQo8WUjePx7zYhbvFHzLpjYMIgaEM6ybQUIx750EY5VGpD4BEOPrICJkU0UQ82+XKRl8+RQ+3c1Q+BC4d9g1xcAbCjCXV80XAco8fGKqvN+pu65h8beVNaFq2v9jm0ghCgCw5Avv5Z4U+dXBreNoZ49m8c94LfNMYpGjiqF666lWePRF3mtEejamVfi5yQ3Ez0KWhuuH3W6hRHqmeZ17e4y9stWIbR/IdJ7j2D5PNcPF7QGSrL/C+txVTH8rP820/heyVzBiEKI=
   on:
-  - tags: true
+    tags: true
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - glide install
 
 script:
-  - make
+  - ./smoketest.sh
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,18 @@ language: go
 go:
   - "1.11.x"
 
-before_install:
-  - sudo add-apt-repository ppa:masterminds/glide -y
-  - sudo apt-get update -q
-  - sudo apt-get install glide -y
+addons:
+  apt:
+    sources:
+      - sourceline: 'ppa:masterminds/glide'
+    packages:
+      - glide
+
+install:
   - glide install
+
+script:
+  - make
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+dist: xenial
+language: go
+go:
+  - "1.11"
+addons:
+  artifacts:
+    paths:
+      - ambex
+    target_paths:
+      - ambex/$TRAVIS_TAG/$(go env GOOS)/$(go env GOARCH)
+    debug: true
+    s3_region: "us-east-1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 dist: xenial
 language: go
 go:
-  - "1.11"
+  - "1.11.x"
+
+before_install:
+  - sudo add-apt-repository ppa:masterminds/glide -y
+  - sudo apt-get update -q
+  - sudo apt-get install glide -y
+
 addons:
   artifacts:
     paths:

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+make image
+docker run --init -p8080:8080 --rm -d --name ambex-envoy bootstrap_image
+docker exec -d -w /application ambex-envoy ./ambex -watch example
+
+for i in {1..10}; do
+    curl -v localhost:8080/hello && break
+    echo "(trial ${i} failed. Sleeping before retrying...)"
+    sleep 1
+done
+
+docker stop ambex-envoy


### PR DESCRIPTION
The smoke test does roughly what the README says to do in Docker. The deploy-on-tag machinery blindly deploys to S3 using whatever tag name you supplied; it deploys the binary for the Docker image, i.e. the stripped Linux binary.